### PR TITLE
fix bug 163783/2016 SMP iOS Device de-registration not removing registration id

### DIFF
--- a/iOS/X509FileCertificateProvider/X509FileCertificateProvider/X509FileCertificateProvider.m
+++ b/iOS/X509FileCertificateProvider/X509FileCertificateProvider/X509FileCertificateProvider.m
@@ -309,5 +309,9 @@ static NSString* const kFileCertificateLabel = @"x509FileCertificateIdentity";
    return error;
 }
 
+- (BOOL) setParameters:(NSDictionary*)params failedWithError:(NSError **)error{
+    //handle the input parameter if needed
+    return YES;
+}
 
 @end


### PR DESCRIPTION
The sample x509 certificate provider does not implement the setParameter method, which is called by custom fiori client to pass the certificate provider's configuration. As a result, an runtime exception happens and crashes the FC application.

The fix adds the setParameter method in the certificate provider to avoid the issue. 

Currently the configuration passed in as the parameter is ignored. If needed, certificate provider developers can update the method to handle the configuration as required.
